### PR TITLE
Allow multiline for $$ latex.

### DIFF
--- a/assets/$$.json
+++ b/assets/$$.json
@@ -1,7 +1,7 @@
 {
     "id": "26a0ef79-b682-4c64-9a90-1dff4f311d15",
     "scriptName": "$$",
-    "findRegex": "/^\\$\\$\\s*\\n*(.*?)\\n*\\s*\\$\\$\\s*$/gm",
+    "findRegex": "/\\$\\$\\s*([\\s\\S]*?)\\s*\\$\\$/g",
     "replaceString": "```latex\n$1\n```",
     "trimStrings": [],
     "placement": [

--- a/assets/latex.json
+++ b/assets/latex.json
@@ -2,7 +2,7 @@
   {
     "id": "26a0ef79-b682-4c64-9a90-1dff4f311d15",
     "scriptName": "$$",
-    "findRegex": "/^\\$\\$\\s*\\n*(.*?)\\n*\\s*\\$\\$\\s*$/gm",
+    "findRegex": "/\\$\\$\\s*([\\s\\S]*?)\\s*\\$\\$/g",
     "replaceString": "```latex\n$1\n```",
     "trimStrings": [],
     "placement": [1, 2, 3],


### PR DESCRIPTION
Original regex doesn't allow multilines between $$

<img width="510" height="235" alt="Screenshot 2025-08-12 at 11 20 03 PM" src="https://github.com/user-attachments/assets/182cc986-a5d8-4c4e-9710-d355452be19b" />

Revised to allow multilines

<img width="504" height="224" alt="Screenshot 2025-08-12 at 11 21 00 PM" src="https://github.com/user-attachments/assets/883709e7-8ba7-42e2-a5e2-32ccf15a0a0d" />
